### PR TITLE
Added a State Machine Pattern

### DIFF
--- a/contracts/solidity_patterns/StateMachine.sol
+++ b/contracts/solidity_patterns/StateMachine.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import "@nilfoundation/smart-contracts/contracts/NilBase.sol";
+
+contract StateMachine is NilBase {
+    enum Stages {
+        Initialize,
+        Processing,
+        Completed,
+        Failed
+    }
+
+    Stages public currentStage;
+    
+    uint256 public processValue;
+    mapping(address => bool) public hasParticipated;
+    
+    event StageAdvanced(Stages newStage);
+    event ProcessValueUpdated(uint256 newValue);
+
+    modifier atStage(Stages _stage) {
+        require(currentStage == _stage, "Invalid stage");
+        _;
+    }
+
+    modifier transitionAfter() {
+        _;
+        _nextStage();
+    }
+
+    constructor() {
+        currentStage = Stages.Initialize;
+    }
+
+    function startProcess() external atStage(Stages.Initialize) transitionAfter {
+        processValue = 0;
+        emit ProcessValueUpdated(processValue);
+    }
+
+    function participate() external atStage(Stages.Processing) {
+        require(!hasParticipated[msg.sender], "Already participated");
+        
+        hasParticipated[msg.sender] = true;
+        processValue += 1;
+        
+        emit ProcessValueUpdated(processValue);
+        
+        if (processValue >= 5) {
+            currentStage = Stages.Completed;
+            emit StageAdvanced(Stages.Completed);
+        }
+    }
+
+    function _nextStage() internal {
+        currentStage = Stages(uint(currentStage) + 1);
+        emit StageAdvanced(currentStage);
+    }
+
+    function reset() external onlyInternal {
+        require(currentStage == Stages.Completed || currentStage == Stages.Failed, 
+                "Can only reset from Completed or Failed state");
+        currentStage = Stages.Initialize;
+        processValue = 0;
+        emit StageAdvanced(Stages.Initialize);
+        emit ProcessValueUpdated(processValue);
+    }
+} 

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -51,9 +51,22 @@ function copyFile(srcFilePath, destFilePath) {
     }
 }
 
+function addPatternCommand() {
+    const packageJsonPath = path.join(projectPath, 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+
+    // Add create-pattern command to scripts
+    packageJson.scripts = packageJson.scripts || {};
+    packageJson.scripts['create-pattern'] = 'node scripts/create-pattern.js';
+
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+}
+
 createPackageJson(templatePath, projectPath);
 copyFile('.env.example', '.env');
 copyFile('ignition/modules/Incrementer.ts', 'ignition/modules/Incrementer.ts');
 copyFile('contracts/Incrementer.sol', 'contracts/Incrementer.sol');
+copyFile('scripts/create-pattern.js', 'scripts/create-pattern.js');
+addPatternCommand();
 
 console.log('Project setup complete!');

--- a/scripts/create-pattern.js
+++ b/scripts/create-pattern.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const PATTERNS = {
+    'access': 'AccessRestriction.sol',
+    'state': 'StateMachine.sol',
+    'guard': 'GuardCheck.sol',
+    'proxy': 'ProxyDelegate.sol',
+    'check': 'CheckEffectsInteraction.sol'
+};
+
+function createPattern(patternName, projectPath) {
+    if (!PATTERNS[patternName]) {
+        console.error(`Invalid pattern name. Available patterns: ${Object.keys(PATTERNS).join(', ')}`);
+        process.exit(1);
+    }
+
+    const templatePath = path.join(__dirname, '..', 'contracts', 'solidity_patterns', PATTERNS[patternName]);
+    const destPath = path.join(projectPath, 'contracts', 'patterns', PATTERNS[patternName]);
+
+    // Create directories if they don't exist
+    fs.mkdirSync(path.join(projectPath, 'contracts', 'patterns'), { recursive: true });
+
+    // Copy pattern file
+    fs.copyFileSync(templatePath, destPath);
+    console.log(`Created ${patternName} pattern at: ${destPath}`);
+}
+
+// Get command line arguments
+const patternName = process.argv[2];
+const projectDir = process.argv[3] || '.';
+
+if (!patternName) {
+    console.error('Please specify a pattern name');
+    console.log(`Available patterns: ${Object.keys(PATTERNS).join(', ')}`);
+    process.exit(1);
+}
+
+createPattern(patternName.toLowerCase(), path.resolve(projectDir)); 


### PR DESCRIPTION
Made the following contributions

1. A State Machine Pattern contract that demonstrates state transitions and stage-based access control.

In Solidity, the State Machine pattern is a design approach that enables a contract to transition through a series of predefined stages, with each stage permitting specific functionalities. This pattern is particularly useful for modeling processes like auctions, crowdfunding, or voting systems, where the contract's behavior evolves over time

2. A new CLI tool to easily add pattern contracts to projects

3. Integration of the pattern creation tool into the main CLI

To use these patterns, developers can:

Use the CLI command: `npm run create-pattern <pattern-name>`
Available patterns: access, state, rate, guard, proxy, check

The patterns will be created in a contracts/patterns directory
These additions would make the repository more valuable for developers by providing:

* More design patterns and examples
* Better tooling for pattern implementation
* Structured approach to common smart contract patterns
* Educational value for blockchain developers
